### PR TITLE
Original +1

### DIFF
--- a/assets/BrowseTables.css
+++ b/assets/BrowseTables.css
@@ -47,6 +47,21 @@ table tr:hover {
     background-color: #e68626;  /* a sort of ochre color */
 }
 
+/* fixed header */
+thead {
+    position:fixed; top:0em;
+}
+
+/* shift the rest with enclosing div ?! */
+.divstyle{ 
+    position:relative;
+    overflow-y:scroll;
+    max-height:90vh;
+    top:1em;
+    display:inline-block;
+}
+
+
 /* cell formatting */
 
 .rowid {

--- a/assets/BrowseTables.css
+++ b/assets/BrowseTables.css
@@ -49,16 +49,7 @@ table tr:hover {
 
 /* fixed header */
 thead {
-    position:fixed; top:0em;
-}
-
-/* shift the rest with enclosing div ?! */
-.divstyle{ 
-    position:relative;
-    overflow-y:scroll;
-    max-height:90vh;
-    top:1em;
-    display:inline-block;
+    positon: sticky; top: 0px;
 }
 
 

--- a/assets/BrowseTables.css
+++ b/assets/BrowseTables.css
@@ -49,7 +49,7 @@ table tr:hover {
 
 /* fixed header */
 thead {
-    positon: sticky; top: 0px;
+    position: sticky; top: 0px;
 }
 
 


### PR DESCRIPTION
Minimal changes version

using position:sticky over :fixed
 - avoids the header misalignment issues
 - generally won't interfere with horizontal scrolling
 - shouldn't need < / div> table wrapper 