### PR TITLE
Add API HTMLTable for Julia's display system

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ using BrowseTables, Tables
 table = Tables.columntable(collect(i == 5 ? (a = missing, b = "string", c = nothing) :
                                    (a = i, b = Float64(i), c = 'a'-1+i) for i in 1:10))
 open_html_table(table) # open in browser
+HTMLTable(table) # show HTML table using Julia's display system
 ```
 
-The package exports three symbols:
+The package exports four symbols:
 
 1. `write_html_table` writes a table to a HTML file,
 2. `open_html_table` writes the table and opens it in a browser using [DefaultApplication.jl](https://github.com/tpapp/DefaultApplication.jl),
 3. `TableOptions` can be used to customize table appearance and HTML options for the above two functions.
+4. `HTMLTable` displays an HTML table using Julia's display system.  It needs a display supporting HTML output (e.g., [IJulia.jl](https://github.com/JuliaLang/IJulia.jl)).
 
 Please read the docstrings for further information. That said, the primary design principle of this package is that it should “just work”, without further tweaking.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,3 +43,11 @@ end
                    "<td class=\"likemissing\">missing</td></tr>\n<tr>" *
                    "<td class=\"rowid\">2</td><td>2</td><td>3</td></tr>\n</tbody>", html)
 end
+
+@testset "HTMLTable" begin
+    tb = (a = 1:2, b = [missing, 3])
+    html = sprint(show, "text/html", HTMLTable(tb))
+    @test occursin("<thead>", html)
+    @test occursin("<tbody>", html)
+    @test occursin("<tfoot>", html)
+end


### PR DESCRIPTION
This PR adds `HTMLTable` struct which implements `show` with `text/html` MIME based on `write_html_table`.  With this PR, you can view a table in, e.g., Jupyter Notebook or `ElectronDisplay` (~if https://github.com/queryverse/ElectronDisplay.jl/pull/8 is merged~; edit: it's merged).